### PR TITLE
Upgrading resolve-url-loader with latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "nginject-loader": "~2.1.0",
     "node-sass": "~3.4.2",
     "omit-tilde-webpack-plugin": "~0.1.1",
-    "resolve-url-loader": "~1.4.3",
+    "resolve-url-loader": "~1.6.1",
     "sass-loader": "~3.1.2",
     "url-loader": "~0.5.7",
     "webpack": "~1.12.12",


### PR DESCRIPTION
Upgraded the `resolve-url-loader` with latest version because there was issue while creating sourceMap.
Error like:
```
WARNING in ./~/css-loader?minimize&sourceMap!(webpack)-angularity-solution/~/resolve-url-loader?sourceMap!./~/sass-loader?sourceMap!./components/num-pad/index.scss
      resolve-url-loader cannot operate: source-map error
      ENOENT: no such file or directory, scandir '/Users/amitesh/ahome/mm/projects/raining/app-build'
```